### PR TITLE
Teach the agent kit the six-language TeaQL workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,11 @@ modeling, generation, or application work, read and follow
    Java, Rust, Go, Python, C#/.NET, and TypeScript. Kotlin/JVM applications are
    also supported through Java-generated libraries and the Java runtime; this
    is JVM interoperability, not a seventh generator/runtime. Do not infer
-   support for an unlisted language. C++, Dart, Swift, Ruby, and other unlisted
-   smaller language ecosystems are not supported. Do not substitute one
-   language's generated API for another.
+   support for an unlisted language. Swift is planned within six weeks, with a
+   target date of 2026-09-25, but is not usable until its generator/runtime is
+   published. C++, Dart, Ruby, and other unlisted smaller language ecosystems
+   are not supported. Do not substitute one language's generated API for
+   another.
 3. Rust requires `cargo-teaql` exactly `2.0.11`. Verify it before every TeaQL
    operation; stop on any mismatch.
 4. Java requires `io.teaql:teaql-maven-plugin:1.1.0` or newer from the TeaQL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,11 @@ modeling, generation, or application work, read and follow
    Service, and fix all Errors before generation. Never run evaluation before
    the first complete model target exists.
 2. TeaQL application generation supports exactly these six language families:
-   Java, Rust, Go, Python, C#/.NET, and TypeScript. Do not infer support for an
-   unlisted language (including C++), and do not substitute one language's
-   generated API for another.
+   Java, Rust, Go, Python, C#/.NET, and TypeScript. Kotlin/JVM applications are
+   also supported through Java-generated libraries and the Java runtime; this
+   is JVM interoperability, not a seventh generator/runtime. Do not infer
+   support for an unlisted language (including C++), and do not substitute one
+   language's generated API for another.
 3. Rust requires `cargo-teaql` exactly `2.0.11`. Verify it before every TeaQL
    operation; stop on any mismatch.
 4. Java requires `io.teaql:teaql-maven-plugin:1.1.0` or newer from the TeaQL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ modeling, generation, or application work, read and follow
    Java, Rust, Go, Python, C#/.NET, and TypeScript. Kotlin/JVM applications are
    also supported through Java-generated libraries and the Java runtime; this
    is JVM interoperability, not a seventh generator/runtime. Do not infer
-   support for an unlisted language (including C++), and do not substitute one
+   support for an unlisted language. C++, Dart, Swift, Ruby, and other unlisted
+   smaller language ecosystems are not supported. Do not substitute one
    language's generated API for another.
 3. Rust requires `cargo-teaql` exactly `2.0.11`. Verify it before every TeaQL
    operation; stop on any mismatch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,23 +9,28 @@ modeling, generation, or application work, read and follow
 1. Work model-first: save complete KSML, evaluate it with the Generation
    Service, and fix all Errors before generation. Never run evaluation before
    the first complete model target exists.
-2. Rust requires `cargo-teaql` exactly `2.0.11`. Verify it before every TeaQL
+2. TeaQL application generation supports exactly these six language families:
+   Java, Rust, Go, Python, C#/.NET, and TypeScript. Do not infer support for an
+   unlisted language (including C++), and do not substitute one language's
+   generated API for another.
+3. Rust requires `cargo-teaql` exactly `2.0.11`. Verify it before every TeaQL
    operation; stop on any mismatch.
-3. Java requires `io.teaql:teaql-maven-plugin:1.1.0` or newer from the TeaQL
+4. Java requires `io.teaql:teaql-maven-plugin:1.1.0` or newer from the TeaQL
    Nexus releases repository. Use fully qualified Maven coordinates, never
    `mvn teaql:*`.
-4. Every Rust model-derived command, including assist, uses
+5. Every Rust model-derived command, including assist, uses
    `cargo teaql --input <model> <command> ...`.
-5. Rust generation uses only `rust-lib-core` and `rust-app-console`.
-6. Never edit generated domain-library files.
-7. Read the generated application/workspace `AGENTS.md` and current
+6. Rust generation uses only `rust-lib-core` and `rust-app-console`.
+7. Never edit generated domain-library files.
+8. Read the generated application/workspace `AGENTS.md` and current
    object-specific assist before business code. Never guess generated methods.
-8. Every query execution declares `.purpose("why")` and `.comment("what")`.
-9. Every write declares `.audit_as("description")` in Rust or the generated
-   Java equivalent, normally `.auditAs("description")`.
-10. When evaluation reaches zero errors, send the model path and evaluation
+9. Every query execution declares purpose and comment through the exact
+   generated API for its language.
+10. Every write declares an audit reason through the exact generated API for
+   its language. Never guess the spelling from Java or Rust examples.
+11. When evaluation reaches zero errors, send the model path and evaluation
     counts, then continue without waiting. Human Review runs in parallel.
-11. Report actual model, assist, policy, compile, test, runtime, and
+12. Report actual model, assist, policy, compile, test, runtime, and
     token/context evidence. Never invent savings or verification results.
 
 The complete pre-simplification repository is recoverable from Git Tag

--- a/README.md
+++ b/README.md
@@ -301,6 +301,23 @@ TeaQL natively supports six major languages. While the core philosophy remains i
 - 🟡 **Partial / WIP:** Feature is partially implemented or under active development.
 - ⚪ **Not Supported:** Feature is not yet implemented or not applicable for this language tier.
 
+### Verified Runtime Snapshot — 2026-08-12
+
+This snapshot records generated-code and real-runtime evidence, not only the
+presence of an adapter or a code template. A green database entry means the
+generated API chain compiled and ran against that database with real
+persistence. Some results are on validated development branches, so merge and
+release availability can lag behind this engineering snapshot.
+
+| Language runtime | Latest verified runtime evidence | Verified databases | Qualification |
+| :--- | :--- | :--- | :--- |
+| [Java](https://github.com/teaql/teaql-java) | Full database matrix: `8 tests / 0 failures / 0 errors / 0 skipped` | PostgreSQL, MySQL, SQLite, Oracle, DB2, SAP HANA, SQL Server, DuckDB | Broadest enterprise database coverage; Android remains SQLite-only |
+| [Rust](https://github.com/teaql/teaql-rs) | Generated API chain and runtime suite passed; runtime branch coverage reached 95.5% | PostgreSQL, MySQL, SQLite | SQL Server is intentionally out of scope |
+| [Go](https://github.com/teaql/teaql-golang) | Runtime suite and generated SQL matrix passed; statement coverage reached 94.9% | PostgreSQL, MySQL, SQLite | Includes generated-query `WithComment` compatibility |
+| [Python](https://github.com/teaql/teaql-python) | `73` runtime tests passed plus generated real-SQL integration | PostgreSQL, MySQL, SQLite | Uses real async SQL providers; no longer counted as JSON/fake persistence |
+| [C# / .NET](https://github.com/teaql/teaql-dotnet) | `124` runtime tests passed plus generated database integration | PostgreSQL, MySQL, SQLite, SQL Server | SQL Server support is specific to Java and .NET |
+| [TypeScript](https://github.com/teaql/teaql-ts) | `6` runtime tests plus `4 tests / 0 failures / 0 errors / 0 skipped` generated matrix | PostgreSQL, MySQL, SQLite | Canonical Node SQL runtime; the browser/TFP entry installs and loads no database driver |
+
 | Feature Area | Java | Rust | Go | Python | C# (.NET) | TypeScript |
 | :--- | :---: | :---: | :---: | :---: | :---: | :---: |
 | **Core Runtime** | | | | | | |
@@ -309,10 +326,16 @@ TeaQL natively supports six major languages. While the core philosophy remains i
 | UserContext & Identity | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
 | Triple-Intent Policy | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
 | **Data Providers** | | | | | | |
-| SQLite | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | ⚪ |
-| MySQL | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | ⚪ |
-| PostgreSQL | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | ⚪ |
+| SQLite | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
+| MySQL | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
+| PostgreSQL | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 | 🟢 |
 | MS SQL Server | 🟢 | ⚪ | ⚪ | ⚪ | 🟢 | ⚪ |
+| Oracle | 🟢 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
+| DB2 | 🟢 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
+| SAP HANA | 🟢 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
+| DuckDB | 🟢 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
+| DM8 (Dameng) | 🟡 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
+| Snowflake | 🟡 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
 | **Advanced Integrations** | | | | | | |
 | Federation Protocol (TFP) Server | 🟢 | 🟢 | 🟢 | ⚪ | 🟢 | ⚪ |
 | TFP HTTP Provider (Client) | ⚪ | ⚪ | ⚪ | 🟢 | ⚪ | 🟢 |
@@ -328,8 +351,14 @@ TeaQL natively supports six major languages. While the core philosophy remains i
 
 > **💡 Note on Java Database Support:**
 > The Java ecosystem has highly adaptable data provider support depending on its execution environment:
-> - **Server / Backend (Spring Boot, Quarkus, etc.):** Leverages `teaql-provider-jdbc` to support an extensive array of enterprise databases beyond what is listed above, including **Oracle, DB2, DM8 (Dameng), DuckDB, SAP HANA, and Snowflake**.
+> - **Server / Backend (Spring Boot, Quarkus, etc.):** The latest full-chain matrix verifies **PostgreSQL, MySQL, SQLite, Oracle, DB2, SAP HANA, SQL Server, and DuckDB**. DM8 has a JDBC provider path but is not part of the latest complete matrix. Snowflake is not counted as verified because no official locally runnable Snowflake database service image was found.
 > - **Android / Mobile (`teaql-android`):** When running natively on mobile, database support is strictly constrained to **SQLite** to ensure local compatibility, zero-configuration, and memory efficiency without pulling in heavy JDBC drivers.
+
+> **💡 Note on TypeScript Profiles:**
+> The green SQL entries apply to the explicit Node.js profiles
+> `teaql-ts/sql/postgres`, `teaql-ts/sql/mysql`, and
+> `teaql-ts/sql/sqlite`. The default `teaql-ts` browser/TFP entry has no SQL
+> import and does not install or load `pg`, `mysql2`, or `better-sqlite3`.
 
 ## TeaQL Generation Service
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,9 @@ and TeaQL Java runtime, as demonstrated by the
 [Compose Desktop vending-machine example](https://github.com/teaql/teaql-java-app-examples/tree/main/002-vending-machine-compose-desktop).
 It is application-language interoperability, not a separate seventh runtime or
 generation target.
+
+C++, Dart, Swift, Ruby, and other unlisted smaller language ecosystems are not
+currently supported.
 - Runtime and tool guides generated for the current domain
 - Data-design, model-view, and frontend model outputs
 

--- a/README.md
+++ b/README.md
@@ -376,8 +376,12 @@ and TeaQL Java runtime, as demonstrated by the
 It is application-language interoperability, not a separate seventh runtime or
 generation target.
 
-C++, Dart, Swift, Ruby, and other unlisted smaller language ecosystems are not
-currently supported.
+Swift support is planned within six weeks, targeting 2026-09-25. Its planned
+shape is a local-first SQLite runtime for iOS and macOS plus a TFP client,
+generated from the same KSML model as a selectable TeaQL backend. It remains a
+roadmap item—not a currently usable target—until generator and runtime evidence
+are published. C++, Dart, Ruby, and other unlisted smaller language ecosystems
+are not currently supported.
 - Runtime and tool guides generated for the current domain
 - Data-design, model-view, and frontend model outputs
 

--- a/README.md
+++ b/README.md
@@ -369,6 +369,12 @@ The Generation Service provides the most complete model-derived output set:
 - Editable application workspaces
 - Model evaluation and repair guidance
 - Object-specific query, create, update, delete, and expression assist
+
+Kotlin/JVM application code is supported through the generated Java library
+and TeaQL Java runtime, as demonstrated by the
+[Compose Desktop vending-machine example](https://github.com/teaql/teaql-java-app-examples/tree/main/002-vending-machine-compose-desktop).
+It is application-language interoperability, not a separate seventh runtime or
+generation target.
 - Runtime and tool guides generated for the current domain
 - Data-design, model-view, and frontend model outputs
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ release availability can lag behind this engineering snapshot.
 
 | Language runtime | Latest verified runtime evidence | Verified databases | Qualification |
 | :--- | :--- | :--- | :--- |
-| [Java](https://github.com/teaql/teaql-java) | Full database matrix: `8 tests / 0 failures / 0 errors / 0 skipped` | PostgreSQL, MySQL, SQLite, Oracle, DB2, SAP HANA, SQL Server, DuckDB | Broadest enterprise database coverage; Android remains SQLite-only |
+| [Java](https://github.com/teaql/teaql-java) | Full database matrix: `9 tests / 0 failures / 0 errors / 0 skipped` | PostgreSQL, MySQL, SQLite, Oracle, DB2, DM8, SAP HANA, SQL Server, DuckDB | Broadest enterprise database coverage; Android remains SQLite-only |
 | [Rust](https://github.com/teaql/teaql-rs) | Generated API chain and runtime suite passed; runtime branch coverage reached 95.5% | PostgreSQL, MySQL, SQLite | SQL Server is intentionally out of scope |
 | [Go](https://github.com/teaql/teaql-golang) | Runtime suite and generated SQL matrix passed; statement coverage reached 94.9% | PostgreSQL, MySQL, SQLite | Includes generated-query `WithComment` compatibility |
 | [Python](https://github.com/teaql/teaql-python) | `73` runtime tests passed plus generated real-SQL integration | PostgreSQL, MySQL, SQLite | Uses real async SQL providers; no longer counted as JSON/fake persistence |
@@ -334,7 +334,7 @@ release availability can lag behind this engineering snapshot.
 | DB2 | 🟢 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
 | SAP HANA | 🟢 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
 | DuckDB | 🟢 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
-| DM8 (Dameng) | 🟡 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
+| DM8 (Dameng) | 🟢 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
 | Snowflake | 🟡 | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
 | **Advanced Integrations** | | | | | | |
 | Federation Protocol (TFP) Server | 🟢 | 🟢 | 🟢 | ⚪ | 🟢 | ⚪ |
@@ -351,7 +351,7 @@ release availability can lag behind this engineering snapshot.
 
 > **💡 Note on Java Database Support:**
 > The Java ecosystem has highly adaptable data provider support depending on its execution environment:
-> - **Server / Backend (Spring Boot, Quarkus, etc.):** The latest full-chain matrix verifies **PostgreSQL, MySQL, SQLite, Oracle, DB2, SAP HANA, SQL Server, and DuckDB**. DM8 has a JDBC provider path but is not part of the latest complete matrix. Snowflake is not counted as verified because no official locally runnable Snowflake database service image was found.
+> - **Server / Backend (Spring Boot, Quarkus, etc.):** The latest full-chain matrix verifies **PostgreSQL, MySQL, SQLite, Oracle, DB2, DM8, SAP HANA, SQL Server, and DuckDB**. Snowflake is not counted as verified because no official locally runnable Snowflake database service image was found.
 > - **Android / Mobile (`teaql-android`):** When running natively on mobile, database support is strictly constrained to **SQLite** to ensure local compatibility, zero-configuration, and memory efficiency without pulling in heavy JDBC drivers.
 
 > **💡 Note on TypeScript Profiles:**

--- a/README.md
+++ b/README.md
@@ -138,15 +138,16 @@ five-stage walkthrough:
 2. Inspect the model as an interactive entity graph or data dictionary.
 3. Evaluate the model, repair reported Errors, and retain the report as
    evidence.
-4. Generate stable domain libraries and separate editable Java or Rust
-   application workspaces.
+4. Generate stable domain libraries and separate editable application
+   workspaces for Java, Rust, Go, Python, C#/.NET, or TypeScript.
 5. Develop against the generated contract with model-, language-, action-, and
    object-specific assist.
 
 The page also exposes a live evaluation report, generation target catalog,
-workspace API guides, and side-by-side Java and Rust previews for create,
+workspace API guides, and language-specific previews and assist for create,
 update, query, list, expression, delete, debugging, granted tool API, and
-runtime customization guidance.
+runtime customization guidance. Preview depth can vary by language; the
+current target catalog and generated assist are authoritative.
 
 This live surface demonstrates that the evaluator, generators, typed
 contracts, and just-in-time assist are concrete parts of the harness rather
@@ -364,7 +365,7 @@ release availability can lag behind this engineering snapshot.
 
 The Generation Service provides the most complete model-derived output set:
 
-- Java and Rust typed domain libraries
+- Java, Rust, Go, Python, C#/.NET, and TypeScript typed domain libraries
 - Editable application workspaces
 - Model evaluation and repair guidance
 - Object-specific query, create, update, delete, and expression assist

--- a/skills/build-teaql-app/SKILL.md
+++ b/skills/build-teaql-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-teaql-app
-description: "Build or change a TeaQL application in Java, Rust, Go, Python, C#/.NET, or TypeScript from a natural-language business requirement. Mandatory order: first draft and save a complete KSML model, then verify the client and evaluate that saved model, repair it through repeated evaluation rounds, and generate only after evaluation reaches zero errors. Use for KSML modeling, six-language TeaQL generation, generated assist APIs, auditable business logic, application verification, or parallel human review."
+description: "Build or change a TeaQL application in Java, Rust, Go, Python, C#/.NET, or TypeScript, including Kotlin/JVM applications that consume Java-generated libraries. Mandatory order: first draft and save a complete KSML model, then verify the client and evaluate that saved model, repair it through repeated evaluation rounds, and generate only after evaluation reaches zero errors. Use for KSML modeling, six-language TeaQL generation, generated assist APIs, auditable business logic, application verification, or parallel human review."
 ---
 
 # Build TeaQL App
@@ -26,8 +26,10 @@ Do not reorder these stages:
 1. Read the target repository's nearest `AGENTS.md`.
 2. Capture the original business requirement, model target path, requested
    language and outputs, and runnable or testable outcome. Supported language
-   families are Java, Rust, Go, Python, C#/.NET, and TypeScript. Do not claim
-   generation support for an unlisted language such as C++.
+   families are Java, Rust, Go, Python, C#/.NET, and TypeScript. A Kotlin/JVM
+   application uses the Java-generated library and Java runtime; do not look
+   for a separate Kotlin generator. Do not claim generation support for an
+   unlisted language such as C++.
 3. Keep a compact evidence ledger while working. Record commands, evaluation
    counts, generated guides, assist calls, policy checks, tests, and artifact
    paths as they occur.
@@ -86,6 +88,7 @@ repair rounds:
    Java/C#: `class`, `new`, `import`, `public`, `default`, `return`;
    Go: `type`, `map`, `range`, `go`, `select`, `interface`;
    Python: `class`, `def`, `from`, `import`, `lambda`, `yield`;
+   Kotlin/JVM application code: `object`, `when`, `is`, `fun`, `val`, `var`;
    TypeScript: `class`, `interface`, `function`, `import`, `export`, `typeof`;
    SQL: `select`, `table`, `transaction`). When a natural business concept is a
    single keyword (e.g., "move"), always use a **two-word compound name** instead

--- a/skills/build-teaql-app/SKILL.md
+++ b/skills/build-teaql-app/SKILL.md
@@ -28,7 +28,9 @@ Do not reorder these stages:
    language and outputs, and runnable or testable outcome. Supported language
    families are Java, Rust, Go, Python, C#/.NET, and TypeScript. A Kotlin/JVM
    application uses the Java-generated library and Java runtime; do not look
-   for a separate Kotlin generator. C++, Dart, Swift, Ruby, and other unlisted
+   for a separate Kotlin generator. Swift support is planned within six weeks
+   (target: 2026-09-25), but must be reported as unavailable until its target
+   appears in the Generation Service. C++, Dart, Ruby, and other unlisted
    smaller language ecosystems are not supported.
 3. Keep a compact evidence ledger while working. Record commands, evaluation
    counts, generated guides, assist calls, policy checks, tests, and artifact

--- a/skills/build-teaql-app/SKILL.md
+++ b/skills/build-teaql-app/SKILL.md
@@ -28,8 +28,8 @@ Do not reorder these stages:
    language and outputs, and runnable or testable outcome. Supported language
    families are Java, Rust, Go, Python, C#/.NET, and TypeScript. A Kotlin/JVM
    application uses the Java-generated library and Java runtime; do not look
-   for a separate Kotlin generator. Do not claim generation support for an
-   unlisted language such as C++.
+   for a separate Kotlin generator. C++, Dart, Swift, Ruby, and other unlisted
+   smaller language ecosystems are not supported.
 3. Keep a compact evidence ledger while working. Record commands, evaluation
    counts, generated guides, assist calls, policy checks, tests, and artifact
    paths as they occur.

--- a/skills/build-teaql-app/SKILL.md
+++ b/skills/build-teaql-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-teaql-app
-description: "Build or change a TeaQL Java or Rust application from a natural-language business requirement. Mandatory order: first draft and save a complete KSML model, then verify the client and evaluate that saved model, repair it through repeated evaluation rounds, and generate only after evaluation reaches zero errors. Use for KSML modeling, TeaQL generation, generated assist APIs, auditable business logic, application verification, or parallel human review."
+description: "Build or change a TeaQL application in Java, Rust, Go, Python, C#/.NET, or TypeScript from a natural-language business requirement. Mandatory order: first draft and save a complete KSML model, then verify the client and evaluate that saved model, repair it through repeated evaluation rounds, and generate only after evaluation reaches zero errors. Use for KSML modeling, six-language TeaQL generation, generated assist APIs, auditable business logic, application verification, or parallel human review."
 ---
 
 # Build TeaQL App
@@ -25,7 +25,9 @@ Do not reorder these stages:
 
 1. Read the target repository's nearest `AGENTS.md`.
 2. Capture the original business requirement, model target path, requested
-   Java/Rust outputs, and runnable or testable outcome.
+   language and outputs, and runnable or testable outcome. Supported language
+   families are Java, Rust, Go, Python, C#/.NET, and TypeScript. Do not claim
+   generation support for an unlisted language such as C++.
 3. Keep a compact evidence ledger while working. Record commands, evaluation
    counts, generated guides, assist calls, policy checks, tests, and artifact
    paths as they occur.
@@ -48,7 +50,11 @@ multiple module files using `<_include file="module.xml" />`, but this is
 optional. The system supports dynamic output limits so a single-file model
 will also work.
 
-- **CRITICAL**: To avoid keyword collisions in generated languages (like `type`, `move`, `match`, `fn`, `struct` in Rust or Java), **ALWAYS use two-word field names and entity names** when there is any risk of conflict (e.g. use `bonus_type` instead of `type`, `move_order` instead of `move`, `leave_type` instead of `type`). Do not use bare single words like `type` or `move` as entity or field names.
+- **CRITICAL**: To avoid keyword collisions in any of the six generated
+  languages, **ALWAYS use two-word field names and entity names** when there
+  is any risk of conflict (e.g. use `bonus_type` instead of `type`,
+  `move_order` instead of `move`, `leave_type` instead of `type`). Do not use
+  bare single words like `type` or `move` as entity or field names.
 
 Apply this minimal contract:
 
@@ -77,7 +83,10 @@ repair rounds:
 2. **Language keyword avoidance.** Entity and field names must not collide with
    programming language keywords (Rust: `move`, `type`, `match`, `self`, `ref`,
    `mod`, `box`, `trait`, `impl`, `use`, `let`, `fn`, `async`, `yield`;
-   Java: `class`, `new`, `import`, `public`, `default`, `return`;
+   Java/C#: `class`, `new`, `import`, `public`, `default`, `return`;
+   Go: `type`, `map`, `range`, `go`, `select`, `interface`;
+   Python: `class`, `def`, `from`, `import`, `lambda`, `yield`;
+   TypeScript: `class`, `interface`, `function`, `import`, `export`, `typeof`;
    SQL: `select`, `table`, `transaction`). When a natural business concept is a
    single keyword (e.g., "move"), always use a **two-word compound name** instead
    (e.g., `move_order`, `move_task`, `type_code`, `match_record`).
@@ -163,7 +172,9 @@ When you finish the repair phase and reach zero errors, output `<phase-complete>
 
 <!-- BLOCK_ID: phase_codegen -->
 Generate only the outputs requested by the user.
-Use the exact Java or Rust generation commands in `references/toolchains.md`.
+Use the exact language target and verification guidance in
+`references/toolchains.md`. Generate only targets actually advertised by the
+Generation Service; never manufacture a target name.
 
 IMPORTANT: If your model is split into multiple files in a directory (e.g., `models/`), you MUST pass the directory path (e.g., `--input models/`), NOT the main entry file (`main.xml`) to the generation commands. Passing only the main file will cause the generation to fail with missing included files.
 
@@ -184,10 +195,14 @@ When generation commands complete successfully with `success=true`, output `<pha
 
 Enforce the API constraint harness:
 
-- Every query execution has `.purpose("why")` and `.comment("what")`.
-- Every Rust `.save()` or `.update()` has `.audit_as("description")`.
-- Every Java save/update has the generated equivalent, normally
-  `.auditAs("description")`.
+- Every query execution has purpose and comment through the generated
+  language-specific API. Comment may be added earlier in the query chain;
+  purpose is the capability boundary that exposes execution.
+- Every save/update has an audit reason through the generated
+  language-specific API.
+- Read assist or generated source before using those APIs. Java and Rust
+  spellings are examples, not names to copy into Go, Python, .NET, or
+  TypeScript.
 - Use the identity/request context required by the generated API.
 
 Compile, test, and smoke-test the requested result. Repair model-derived

--- a/skills/build-teaql-app/agents/openai.yaml
+++ b/skills/build-teaql-app/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Build TeaQL App"
   short_description: "Build a verified TeaQL app in any supported language"
-  default_prompt: "Use $build-teaql-app to select Java, Rust, Go, Python, C#/.NET, or TypeScript; first draft and save a complete KSML model, then evaluate and repair it before generating and testing a runnable TeaQL application."
+  default_prompt: "Use $build-teaql-app to select Java, Rust, Go, Python, C#/.NET, or TypeScript—or Java output for a Kotlin/JVM app; first draft and save a complete KSML model, then evaluate and repair it before generating and testing a runnable TeaQL application."
 policy:
   allow_implicit_invocation: true

--- a/skills/build-teaql-app/agents/openai.yaml
+++ b/skills/build-teaql-app/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Build TeaQL App"
-  short_description: "Model first, then evaluate and build a TeaQL application"
-  default_prompt: "Use $build-teaql-app to first draft and save a complete KSML model, then evaluate and repair it before generating a runnable TeaQL application."
+  short_description: "Build a verified TeaQL app in any supported language"
+  default_prompt: "Use $build-teaql-app to select Java, Rust, Go, Python, C#/.NET, or TypeScript; first draft and save a complete KSML model, then evaluate and repair it before generating and testing a runnable TeaQL application."
 policy:
   allow_implicit_invocation: true

--- a/skills/build-teaql-app/references/toolchains.md
+++ b/skills/build-teaql-app/references/toolchains.md
@@ -38,6 +38,13 @@ supported core and editable application targets include:
 | C#/.NET | `dotnet-lib-core` | `dotnet-web-aspnet` |
 | TypeScript | `typescript-lib-core` | `typescript-web-hono` |
 
+Kotlin/JVM applications use `java-lib-core` and the TeaQL Java runtime. Kotlin
+is a supported application language through JVM interoperability, but there is
+no separate `kotlin-*` generation target. Compile and test it with the target
+Gradle or Maven build. The
+[Compose Desktop vending-machine example](https://github.com/teaql/teaql-java-app-examples/tree/main/002-vending-machine-compose-desktop)
+is the reference shape.
+
 C++ is not a supported target. Do not interpret the six-language list as
 support for every language other than C++.
 

--- a/skills/build-teaql-app/references/toolchains.md
+++ b/skills/build-teaql-app/references/toolchains.md
@@ -45,8 +45,9 @@ Gradle or Maven build. The
 [Compose Desktop vending-machine example](https://github.com/teaql/teaql-java-app-examples/tree/main/002-vending-machine-compose-desktop)
 is the reference shape.
 
-C++ is not a supported target. Do not interpret the six-language list as
-support for every language other than C++.
+C++, Dart, Swift, Ruby, and other unlisted smaller language ecosystems are not
+supported targets. Do not interpret the six-language list plus Kotlin/JVM
+interoperability as universal language support.
 
 ## Rust
 

--- a/skills/build-teaql-app/references/toolchains.md
+++ b/skills/build-teaql-app/references/toolchains.md
@@ -23,6 +23,24 @@ invoked. Do not clone toolchain source, hand-build generated outputs, or use an
 older cached client as a fallback. The built-in Generation Service credential
 supports normal use; do not search for an additional API key.
 
+## Supported language targets
+
+TeaQL supports six language families. Ask the Generation Service for its
+current target list and use only a returned target name. The currently
+supported core and editable application targets include:
+
+| Language | Core library | Editable application |
+| --- | --- | --- |
+| Java | `java-lib-core` | `java-web-spring-boot` |
+| Rust | `rust-lib-core` | `rust-app-console` |
+| Go | `golang-lib-core` | `golang-app-console`, `golang-web-gin` |
+| Python | `python-lib-core` | `python-web-fastapi` |
+| C#/.NET | `dotnet-lib-core` | `dotnet-web-aspnet` |
+| TypeScript | `typescript-lib-core` | `typescript-web-hono` |
+
+C++ is not a supported target. Do not interpret the six-language list as
+support for every language other than C++.
+
 ## Rust
 
 Every model-derived command, including dynamic assist, must use
@@ -96,3 +114,23 @@ Verify from the generated workspace:
 mvn clean compile
 mvn test
 ```
+
+## Go, Python, C#/.NET, and TypeScript
+
+Use the Generation Service client available in the target repository, passing
+the saved model and one exact target from the table above. Before adding
+business logic, read the generated workspace `AGENTS.md`, its README, and the
+current object/action assist. The generated API—not a translated Java or Rust
+example—is authoritative.
+
+Run the native verification appropriate to the generated workspace:
+
+```text
+Go:         go test ./...
+Python:     python -m pytest
+C#/.NET:    dotnet build -p:UseSharedCompilation=false; dotnet test -p:UseSharedCompilation=false
+TypeScript: use Node.js 22, install from the lockfile, then run the generated package's test and build scripts
+```
+
+Do not silently skip a missing compiler, runtime, database driver, test script,
+or generated assist surface. Report it as a concrete verification gap.

--- a/skills/build-teaql-app/references/toolchains.md
+++ b/skills/build-teaql-app/references/toolchains.md
@@ -45,9 +45,28 @@ Gradle or Maven build. The
 [Compose Desktop vending-machine example](https://github.com/teaql/teaql-java-app-examples/tree/main/002-vending-machine-compose-desktop)
 is the reference shape.
 
-C++, Dart, Swift, Ruby, and other unlisted smaller language ecosystems are not
-supported targets. Do not interpret the six-language list plus Kotlin/JVM
-interoperability as universal language support.
+## Planned Swift support
+
+Swift is planned within six weeks, targeting 2026-09-25. The planned scope is:
+
+- generated Swift entities, requests, expressions, and user context from the
+  same KSML model used by the server;
+- a local-first SQLite runtime for iOS and macOS applications;
+- a TFP federation client, but no Swift federation server;
+- language-native purpose/comment, audited writes, optimistic locking, hard
+  limits, transactions, and verification guidance;
+- interoperability with TeaQL servers implemented in any of the six supported
+  backend languages, while trusted identity, tenant, permission, and purpose
+  policy remain server-controlled.
+
+This is a roadmap statement, not a usable target. Until a Swift target appears
+in the Generation Service catalog and its runtime evidence passes, do not
+generate placeholder Swift code or claim that a Swift application was
+verified.
+
+C++, Dart, Ruby, and other unlisted smaller language ecosystems are not
+supported targets. Do not interpret the six-language list, Kotlin/JVM
+interoperability, and the Swift roadmap as universal language support.
 
 ## Rust
 

--- a/skills/build-teaql-app/references/work-complete.md
+++ b/skills/build-teaql-app/references/work-complete.md
@@ -66,6 +66,10 @@ methods must come from the local generated guide and assist output.
 
 Typical constrained shapes:
 
+The Java and Rust snippets below are examples only. For Go, Python, C#/.NET,
+and TypeScript, record and use the exact generated assist surface instead of
+translating these method names mechanically.
+
 ```rust
 Q::merchants()
     .purpose("Find merchants for search results")


### PR DESCRIPTION
## Summary

- declare Java, Rust, Go, Python, C#/.NET, and TypeScript as the six supported TeaQL language families
- make generated language-specific assist authoritative for query purpose/comment and audited writes
- document current core-library and editable-workspace generation targets
- add native verification guidance so agents can compile and test each generated language
- retain the verified six-language runtime/database status updates already prepared on this branch
- explicitly avoid inferring C++ or other unlisted language support

## Verification

- skill frontmatter parsed successfully
- OpenAI agent YAML parsed successfully
- `git diff --check` passed
- six-language names and six core generation targets checked in prompt sources

## Worktree note

The pre-existing untracked `skills/build-teaql-app/agents/ERROR-FIX.md` file is not included in this PR.
